### PR TITLE
use nan@2.14.0 to fix building

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "bindings": "^1.2.0",
     "debug": "^2.2.0",
-    "nan": "^2.2.0"
+    "nan": "2.14.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
There was error in building in node 12.16.1 because of old version of **nan**

![image](https://user-images.githubusercontent.com/37391150/76144591-06470c80-6093-11ea-9051-4777dc7878d5.png)

> In file included from ../src/time.cc:5:
In file included from ../../nan/nan.h:223:
In file included from ../../nan/nan_new.h:189:
../../nan/nan_implementation_12_inl.h:356:37: error: too few arguments to function call, expected 2, have 1
  return v8::StringObject::New(value).As<v8::StringObject>();
         ~~~~~~~~~~~~~~~~~~~~~      ^
/Users/macos/Library/Caches/node-gyp/12.16.1/include/node/v8.h:5531:3: note: 'New' declared here
  static Local<Value> New(Isolate* isolate, Local<String> value);
  ^
In file included from ../src/time.cc:5:
In file included from ../../nan/nan.h:223:
In file included from ../../nan/nan_new.h:189:
../../nan/nan_implementation_12_inl.h:356:58: error: expected '(' for function-style cast or type construction
  return v8::StringObject::New(value).As<v8::StringObject>();
                                         ~~~~~~~~~~~~~~~~^
../../nan/nan_implementation_12_inl.h:356:60: error: expected expression
  return v8::StringObject::New(value).As<v8::StringObject>();
                                                           ^
In file included from ../src/time.cc:5:
In file included from ../../nan/nan.h:2722:
../../nan/nan_object_wrap.h:24:25: error: no member named 'IsNearDeath' in 'Nan::Persistent<v8::Object, v8::NonCopyablePersistentTraits<v8::Object> >'
    assert(persistent().IsNearDeath());
           ~~~~~~~~~~~~ ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:93:25: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __FILE__, __LINE__, #e) : (void)0)
                        ^
In file included from ../src/time.cc:5:
In file included from ../../nan/nan.h:2722:
../../nan/nan_object_wrap.h:127:26: error: no member named 'IsNearDeath' in 'Nan::Persistent<v8::Object, v8::NonCopyablePersistentTraits<v8::Object> >'
    assert(wrap->handle_.IsNearDeath());
           ~~~~~~~~~~~~~ ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:93:25: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __FILE__, __LINE__, #e) : (void)0)
